### PR TITLE
Supporting Document DB

### DIFF
--- a/server/2.1/Dockerfile
+++ b/server/2.1/Dockerfile
@@ -7,7 +7,8 @@ LABEL maintainer="Debezium Community"
 #
 ENV DEBEZIUM_VERSION=2.1.4.Final \
     SERVER_HOME=/debezium \
-    MAVEN_REPO_CENTRAL="https://repo1.maven.org/maven2"
+    MAVEN_REPO_CENTRAL="https://repo1.maven.org/maven2" \
+    AWS_MSK_IAM_VERSION=1.1.6
 ENV SERVER_URL_PATH=io/debezium/debezium-server-dist/$DEBEZIUM_VERSION/debezium-server-dist-$DEBEZIUM_VERSION.tar.gz \
     SERVER_MD5=34678858122468d97c36f22fb52f1377
 
@@ -19,13 +20,6 @@ RUN microdnf -y install gzip && \
     microdnf clean all && \
     mkdir $SERVER_HOME && \
     chmod 755 $SERVER_HOME
-
-#
-# Change ownership and switch user
-#
-RUN chown -R jboss $SERVER_HOME && \
-    chgrp -R jboss $SERVER_HOME
-USER jboss
 
 RUN mkdir $SERVER_HOME/conf && \
     mkdir $SERVER_HOME/data
@@ -41,6 +35,21 @@ RUN curl -fSL -o /tmp/debezium.tar.gz "$MAVEN_REPO_CENTRAL/$SERVER_URL_PATH"
 RUN echo "$SERVER_MD5 /tmp/debezium.tar.gz" | md5sum -c - &&\
     tar xzf /tmp/debezium.tar.gz -C $SERVER_HOME --strip-components 1 &&\
     rm -f /tmp/debezium.tar.gz
+
+#
+# Download AWS IAM jar and put it in /debezium/lib
+#
+RUN curl -fSL -o "$SERVER_HOME/lib/aws-msk-iam-auth-all.jar" https://github.com/aws/aws-msk-iam-auth/releases/download/v$AWS_MSK_IAM_VERSION/aws-msk-iam-auth-$AWS_MSK_IAM_VERSION-all.jar
+
+#
+# Now install all the Amazon related certs for DocumentDB TLS
+# https://docs.aws.amazon.com/documentdb/latest/developerguide/connect_programmatically.html#w139aac29c11c13b5b9
+#
+COPY setup_certs.sh /app/setup_certs.sh
+RUN microdnf -y install curl openssl perl
+RUN chmod +x /app/setup_certs.sh
+RUN mkdir -p /tmp/certs
+RUN /app/setup_certs.sh
 
 #
 # Allow random UID to use Debezium Server

--- a/server/2.1/setup_certs.sh
+++ b/server/2.1/setup_certs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# IMPORTANT: DO NOT MODIFY THIS SCRIPT, THIS WAS COPIED FROM: https://docs.aws.amazon.com/documentdb/latest/developerguide/connect_programmatically.html#w139aac29c11c13b5b9
+mydir=/tmp/certs
+truststore=${mydir}/rds-truststore.jks
+storepassword=artie123
+
+curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" > ${mydir}/global-bundle.pem
+awk 'split_after == 1 {n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1}{print > "rds-ca-" n ".pem"}' < ${mydir}/global-bundle.pem
+
+for CERT in rds-ca-*; do
+  alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print')
+  echo "Importing $alias"
+  keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt
+  rm $CERT
+done
+
+rm ${mydir}/global-bundle.pem
+
+echo "Trust store content is: "
+
+keytool -list -v -keystore "$truststore" -storepass ${storepassword} | grep Alias | cut -d " " -f3- | while read alias
+do
+   expiry=`keytool -list -v -keystore "$truststore" -storepass ${storepassword} -alias "${alias}" | grep Valid | perl -ne 'if(/until: (.*?)\n/) { print "$1\n"; }'`
+   echo " Certificate ${alias} expires in '$expiry'"
+done
+


### PR DESCRIPTION
Debezium 2.1 is the last version of Debezium that supports `mongodb.hosts` and `mongodb.members.auto.discover` to be set, so we can bypass the auto discovery process which would kill our ability to run SSH tunneling for MongoDB.

This PR does the following:
* Inject AWS IAM dependency into the Docker image
* Convert `global-bundle.pem` which contains ~180 certs into `JKS` (JKS can only take one cert at a time)
